### PR TITLE
Bugfix: Disappearing quest areas / tracking options with tracking overrides.

### DIFF
--- a/FarmHud.lua
+++ b/FarmHud.lua
@@ -234,9 +234,10 @@ local function TrackingTypes_Update(bool, id)
 		end
 
 		if bool==false and mps.minimapTrackedInfov3 then
-			-- try to restore on close. blizzard changing it outside the lua code area.
+			-- Restore minimap tracked info (quest areas, POI, etc.) on close. Blizzard can change it outside Lua.
 			mTI = mps.minimapTrackedInfov3>0 and mps.minimapTrackedInfov3 or 1006319;
-			C_Timer.After(0.314159,function() C_CVar.SetCVar("minimapTrackedInfov3",mTI) end);
+			C_CVar.SetCVar("minimapTrackedInfov3", mTI);
+			C_Timer.After(0.314159, function() C_CVar.SetCVar("minimapTrackedInfov3", mTI) end);
 		end
 
 		return;
@@ -1243,12 +1244,12 @@ function FarmHudMixin:OnLoad()
 	end
 
 	if not ns.IsClassic() then
-		local function hookSetTracking(index,bool)
-			if not trackingHookLocked and FarmHud:IsVisible() and trackingTypesStates[index]~=nil then
-				trackingTypesStates[index]=nil;
-			end
-		end
-		hooksecurefunc(C_Minimap,"SetTracking",hookSetTracking);
+		-- Do NOT clear trackingTypesStates when the game or other addons call SetTracking.
+		-- Clearing caused overridden tracking (e.g. quest area) to never be restored on hide,
+		-- and caused tracking options to "drop" (e.g. mining suddenly disabled).
+		-- We always restore saved state on FarmHud hide so the real minimap matches pre-show state.
+		-- (If the user changes tracking via Blizzard UI while FarmHud is open, we will overwrite
+		-- that on hide; that is acceptable to avoid broken quest areas and dropped tracking.)
 	end
 
 	function self.cluster:GetZoom()

--- a/FarmHud.lua
+++ b/FarmHud.lua
@@ -238,6 +238,7 @@ local function TrackingTypes_Update(bool, id)
 			mTI = mps.minimapTrackedInfov3>0 and mps.minimapTrackedInfov3 or 1006319;
 			C_CVar.SetCVar("minimapTrackedInfov3", mTI);
 			C_Timer.After(0.314159, function() C_CVar.SetCVar("minimapTrackedInfov3", mTI) end);
+			C_Timer.After(1.5, function() C_CVar.SetCVar("minimapTrackedInfov3", mTI) end);
 		end
 
 		return;
@@ -245,21 +246,22 @@ local function TrackingTypes_Update(bool, id)
 	local key,data = "tracking^"..id,trackingTypes[id];
 	local info = C_Minimap.GetTrackingInfo(data.index) or {};
 	trackingHookLocked = true;
+	-- Key by texture id (id), not index: Blizzard can change tracking order (e.g. zone/quest), so index at hide may differ from show.
 	if bool then
 		if FarmHudDB[key]=="client" then
-			if trackingTypesStates[data.index]~=nil then
-				C_Minimap.SetTracking(data.index,trackingTypesStates[data.index]);
-				trackingTypesStates[data.index] = nil;
+			if trackingTypesStates[id]~=nil then
+				C_Minimap.SetTracking(data.index,trackingTypesStates[id]);
+				trackingTypesStates[id] = nil;
 			end
 		elseif FarmHudDB[key]~=tostring(info.active) then
-			if trackingTypesStates[data.index]==nil then
-				trackingTypesStates[data.index] = info.active;
+			if trackingTypesStates[id]==nil then
+				trackingTypesStates[id] = info.active;
 			end
 			C_Minimap.SetTracking(data.index,FarmHudDB[key]=="true");
 		end
-	elseif not bool and trackingTypesStates[data.index]~=nil then
-		C_Minimap.SetTracking(data.index,trackingTypesStates[data.index]);
-		trackingTypesStates[data.index] = nil;
+	elseif not bool and trackingTypesStates[id]~=nil then
+		C_Minimap.SetTracking(data.index,trackingTypesStates[id]);
+		trackingTypesStates[id] = nil;
 	end
 	trackingHookLocked = false;
 end


### PR DESCRIPTION
### Fix: Quest areas / other tracking options disappearing when using FarmHud tracking overrides

### Problem
If you used FarmHud’s tracking overrides to hide some things only on the HUD (e.g. quest POIs) while keeping them on the normal minimap, quest areas (gold/blue) could disappear and not come back, and other tracking (e.g. mining) could turn off by itself. This only happened when using FarmHud’s own tracking settings (i.e. any other setting besides “like minimap”). The only temporary fix was “Uncheck all” in the Blizzard minimap tracking menu but the issue would reoccur eventually.

### Cause
FarmHud was clearing its saved tracking state whenever anything (including the game) called the minimap tracking API. That meant it sometimes had nothing to restore when FarmHud was closed, so overridden options (including quest-related ones) were never restored.

### Fix
Stopped clearing the saved tracking state when the game or other addons change tracking. FarmHud now always restores the tracking state it had when you opened it, so quest areas and other tracking come back correctly when you close FarmHud.
Restored the minimapTrackedInfov3 CVar (quest areas/POI) both immediately and once after a short delay when FarmHud hides, so the client reliably shows quest areas again.

### Trade-off
If you change a tracking option via the Blizzard minimap tracking menu while FarmHud is open, that change may be reverted when you close FarmHud and reopen it again, because we now always reapply the state from when FarmHud was shown. This is intentional so we don’t leave quest areas or other tracking broken.

Fixes [Issue #18](https://github.com/HizurosWoWAddOns/FarmHud/issues/18)