### PR TITLE
Added TomTom support for hiding crazy arrow with option

### DIFF
--- a/FarmHud.toc
+++ b/FarmHud.toc
@@ -17,7 +17,7 @@
 ## Notes: Turns your minimap into a hud for gathering resources!
 ## IconTexture: 134215
 ## Author: Hizuro, CodeRedLin
-## OptionalDeps: Ace3, CallbackHandler-1.0, LibDBIcon-1.0, LibStub, HereBeDragons
+## OptionalDeps: Ace3, CallbackHandler-1.0, LibDBIcon-1.0, LibStub, HereBeDragons, TomTom
 ## SavedVariables: FarmHudDB
 
 ## X-Curse-Project-ID: 29767

--- a/FarmHud.xml
+++ b/FarmHud.xml
@@ -12,6 +12,7 @@
 	<Script file="modules/CardinalPoints.lua"/>
 	<Script file="modules/TrailPath.lua"/>
 	<Script file="modules/RangeCircles.lua" />
+	<Script file="modules/TomTom.lua" />
 
 	<FontString name="FarmHudFont" inherits="SystemFont_Small2" outline="THICK" hidden="true" virtual="true">
 		<Shadow>

--- a/modules/TomTom.lua
+++ b/modules/TomTom.lua
@@ -1,0 +1,113 @@
+local _, ns = ...;
+local L = ns.L;
+
+local suppressArrow = false;
+local hookInstalled = false;
+
+local module = {
+	dbDefaults = {
+		hideTomTomArrow = false,
+	},
+	events = {},
+};
+
+local function IsTomTomAvailable()
+	local TomTom = _G.TomTom;
+	return TomTom and _G.TomTomCrazyArrow and TomTom.ShowHideCrazyArrow;
+end
+
+local function InstallShowHook()
+	if hookInstalled or not _G.TomTomCrazyArrow then
+		return;
+	end
+	hooksecurefunc(_G.TomTomCrazyArrow, "Show", function(self)
+		if suppressArrow then
+			self:Hide();
+		end
+	end);
+	hookInstalled = true;
+end
+
+local function SetSuppressed(state)
+	if not IsTomTomAvailable() then
+		return;
+	end
+
+	InstallShowHook();
+	suppressArrow = state;
+
+	if state then
+		_G.TomTomCrazyArrow:Hide();
+	elseif _G.TomTom.ShowHideCrazyArrow then
+		_G.TomTom:ShowHideCrazyArrow();
+	end
+end
+
+local function ShouldSuppress()
+	return FarmHudDB.hideTomTomArrow and IsTomTomAvailable();
+end
+
+local function ApplySuppression()
+	SetSuppressed(ShouldSuppress());
+end
+
+function module.OnShow()
+	if ShouldSuppress() then
+		SetSuppressed(true);
+	end
+end
+
+function module.OnHide()
+	if IsTomTomAvailable() then
+		SetSuppressed(false);
+	end
+end
+
+function module.UpdateOptions(key)
+	if key == "hideTomTomArrow" then
+		ApplySuppression();
+	end
+end
+
+function module.events.ADDON_LOADED(loadedAddon)
+	if loadedAddon == "TomTom" and FarmHud:IsShown() and FarmHudDB.hideTomTomArrow then
+		SetSuppressed(true);
+	end
+end
+
+local function opt(info, value)
+	local key = info[#info];
+	if value ~= nil then
+		FarmHudDB[key] = value;
+		module.UpdateOptions(key);
+	end
+	return FarmHudDB[key];
+end
+
+local options = {
+	integrations = {
+		type = "group",
+		order = 98,
+		name = "TomTom",
+		hidden = function()
+			return not IsTomTomAvailable();
+		end,
+		get = opt,
+		set = opt,
+		args = {
+			hideTomTomArrow = {
+				type = "toggle",
+				order = 1,
+				width = "full",
+				name = L["HideTomTomArrow"],
+				desc = L["HideTomTomArrowDesc"],
+			},
+		},
+	},
+};
+
+function module.AddOptions()
+	return options;
+end
+
+ns.modules["TomTomIntegration"] = module;


### PR DESCRIPTION
This PR adds the ability to enable an option for hiding the TomTom crazy arrow when FarmHud is shown and restores it when closed. The reason for this is that the FarmHud already shows an arrow to follow and having 2 arrows is less relevant when FarmHud is shown, and is more immersive when hidden.

I personally like this, but the option is disabled by default. 

Also, I added localisation, but I wasn't sure how to package it using the packaging syntax so I left that out of the commits.
Here they are if you need it:

```
L["HideTomTomArrow"] = "Hide TomTom arrow"
L["HideTomTomArrowDesc"] = "Hides TomTom's Crazy Arrow while FarmHud is open and restores it when FarmHud closes."

-- deDE:
L["HideTomTomArrow"] = "TomTom-Pfeil verstecken"
L["HideTomTomArrowDesc"] = "Blendet TomToms Crazy Arrow aus, solange FarmHud geöffnet ist, und stellt ihn wieder her, wenn FarmHud geschlossen wird."

-- ruRU:
L["HideTomTomArrow"] = "Скрывать стрелку TomTom"
L["HideTomTomArrowDesc"] = "Скрывает Crazy Arrow TomTom, пока открыт FarmHud, и восстанавливает его при закрытии FarmHud."

-- zhCN:
L["HideTomTomArrow"] = "隐藏 TomTom 箭头"
L["HideTomTomArrowDesc"] = "在 FarmHud 打开时隐藏 TomTom 的 Crazy Arrow，关闭 FarmHud 时恢复。"
```

This is without the change:
<img width="802" height="865" alt="image" src="https://github.com/user-attachments/assets/5382d562-c8be-4c1c-88a2-c10a476c250d" />

As you can see, I see both arrows and this feature removes the bigger arrow that I still like to use when not using FarmHud.

This is with the change:
<img width="683" height="851" alt="image" src="https://github.com/user-attachments/assets/aad4b9ee-127e-4124-937a-24a9ed784d3c" />

This is the option I've added:
<img width="732" height="340" alt="image" src="https://github.com/user-attachments/assets/e1bfe88e-fe2b-45e9-b979-a4d10e685c05" />
